### PR TITLE
Add support for pull and init parameters in podman containers

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -96,6 +96,7 @@
     state: "{{ item.state | default('created') }}"
     recreate: "{{ item.recreate | default(podman_recreate) | default(true) }}"
     image: "{{ item.image }}:{{ item.tag }}"
+    pull: "{{ item.pull | default(omit) }}"
     init: "{{ item.init | default(omit) }}"
     command: "{{ item.command | default(omit) }}"
     volumes: "{{ item.volumes | default(omit) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -96,6 +96,7 @@
     state: "{{ item.state | default('created') }}"
     recreate: "{{ item.recreate | default(podman_recreate) | default(true) }}"
     image: "{{ item.image }}:{{ item.tag }}"
+    init: "{{ item.init | default(omit) }}"
     command: "{{ item.command | default(omit) }}"
     volumes: "{{ item.volumes | default(omit) }}"
     env: "{{ item.env | default(omit) }}"


### PR DESCRIPTION
This PR adds support for two additional configuration parameters when creating Podman containers:

- **pull**: Allows configurable image pull policies per container (pull_policy in Podman)
- **init**: Enables the init process within containers, wrapped with catatonit on Podman

The `init` parameter is important for applications using multi-process architectures (like Playwright/Chromium-based tools or Celery workers). Without an init system as PID 1, the container cannot properly reap orphaned child processes, leading to zombie processes that persist until the container is destroyed. Enabling `init: true` ensures proper process management and signal forwarding.

Both parameters are optional and default to omitted, maintaining backward compatibility with existing configurations.